### PR TITLE
Bump GRPC_HEALTH_PROBE_VERSION to 0.4.23

### DIFF
--- a/server-base.hcl
+++ b/server-base.hcl
@@ -41,7 +41,7 @@ variable "UBUNTU_VERSION" {
 }
 
 variable "GRPC_HEALTH_PROBE_VERSION" {
-    default = "0.4.22"
+    default = "0.4.23"
 }
 
 variable "TAG" {

--- a/server-slim-base.hcl
+++ b/server-slim-base.hcl
@@ -27,7 +27,7 @@ variable "UBUNTU_VERSION" {
 }
 
 variable "GRPC_HEALTH_PROBE_VERSION" {
-    default = "0.4.22"
+    default = "0.4.23"
 }
 
 variable "TAG" {

--- a/server-slim.hcl
+++ b/server-slim.hcl
@@ -37,7 +37,7 @@ variable "UBUNTU_VERSION" {
 }
 
 variable "GRPC_HEALTH_PROBE_VERSION" {
-    default = "0.4.22"
+    default = "0.4.23"
 }
 
 variable "TAG" {

--- a/server.hcl
+++ b/server.hcl
@@ -55,7 +55,7 @@ variable "UBUNTU_VERSION" {
 }
 
 variable "GRPC_HEALTH_PROBE_VERSION" {
-    default = "0.4.22"
+    default = "0.4.23"
 }
 
 variable "TAG" {


### PR DESCRIPTION
See https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.23