### PR TITLE
Migrate from gradle-cache-action to setup-gradle

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -41,12 +41,13 @@ jobs:
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Assemble distribution
-        uses: burrunan/gradle-cache-action@v1
         with:
           job-id: build-server
-          arguments: --scan outputVersion server-jetty-app:assemble py-server:assemble
-          gradle-version: wrapper
+        run: ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -45,8 +45,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble distribution
-        with:
-          job-id: build-server
         run: ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/edge-ci.yml
+++ b/.github/workflows/edge-ci.yml
@@ -39,12 +39,13 @@ jobs:
           .github/scripts/gradle-properties.sh >> gradle.properties
           cat gradle.properties
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Assemble distribution
-        uses: burrunan/gradle-cache-action@v1
         with:
           job-id: build-server
-          arguments: --scan outputVersion server-jetty-app:assemble py-server:assemble
-          gradle-version: wrapper
+        run: ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/edge-ci.yml
+++ b/.github/workflows/edge-ci.yml
@@ -43,8 +43,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble distribution
-        with:
-          job-id: build-server
         run: ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
burrunan/gradle-cache-action seems unmaintained, with the last release in August 2020.

gradle/actions/setup-gradle is the officially maintained by Gradle action that has been getting a lot of work done recently.

This also removes the build scans. We've never needed to use build scans in context with these jobs in the past. This could be changed in the future if necessary.

See https://github.com/deephaven/deephaven-core/issues/5161