### PR TITLE
Add latest image check in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,8 +83,7 @@ In cases where that's not true, there's a good chance that care may be needed to
 In the case of a patch release, the branch may, or may not, be fast-forwardable.
 Use care, and ensure any merge conflicts are handled appropriately before pushing.
 
-[!CAUTION]
-If the release is a patch on an older release (i.e. not the latest), do not merge the release branch.
+> :warning: If the release is a patch on an older release (i.e. not the latest), do not merge the release branch.
 
 ```shell
 $ git checkout main

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,10 @@ If all is green, you should be able to test the new release:
 ```shell
 $ docker run --rm --name deephaven -p 10000:10000 ghcr.io/deephaven/server:X.Y.Z
 ```
+If the release is the latest version, match the version from the latest image
+```shell
+$ docker run --rm --name deephaven -p 10000:10000 ghcr.io/deephaven/server:latest
+```
 
 The docker image release process is more forgiving than releasing jar artifacts.
 If something goes wrong during this stage, it can easily be corrected.
@@ -77,7 +81,10 @@ Typically, the fast-forward be successful during a normal release since the rele
 In cases where that's not true, there's a good chance that care may be needed to ensure any merge conflicts are handled appropriately.
 
 In the case of a patch release, the branch may, or may not, be fast-forwardable.
-Use care, and ensure any merge conflicts are handled appropriately before pushing:
+Use care, and ensure any merge conflicts are handled appropriately before pushing.
+
+[!CAUTION]
+If the release is a patch on an older release (i.e. not the latest), do not merge the release branch.
 
 ```shell
 $ git checkout main

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,7 +54,8 @@ If all is green, you should be able to test the new release:
 ```shell
 $ docker run --rm --name deephaven -p 10000:10000 ghcr.io/deephaven/server:X.Y.Z
 ```
-If the release is the latest version, match the version from the latest image
+Verify that the latest version, which may not be `X.Y.Z`, is correct in the `latest` image.
+
 ```shell
 $ docker run --rm --name deephaven -p 10000:10000 ghcr.io/deephaven/server:latest
 ```
@@ -63,7 +64,6 @@ The docker image release process is more forgiving than releasing jar artifacts.
 If something goes wrong during this stage, it can easily be corrected.
 
 ### 3. Merge release branch to main
-
 
 During a normal release, follow-up with a fast-forward merge of `release/vX.Y.Z` into `main`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,7 +83,7 @@ In cases where that's not true, there's a good chance that care may be needed to
 In the case of a patch release, the branch may, or may not, be fast-forwardable.
 Use care, and ensure any merge conflicts are handled appropriately before pushing.
 
-> :warning: If the release is a patch on an older release (i.e. not the latest), do not merge the release branch.
+> :warning: If the release is a patch on an older release (i.e. not the latest), skip the following section.
 
 ```shell
 $ git checkout main


### PR DESCRIPTION
Added some instructions for extra checking on the `latest` tag in the case where an older version is begin patched.