### PR TITLE
Add docstring_parser 0.16

### DIFF
--- a/contexts/server-base/requirements.txt
+++ b/contexts/server-base/requirements.txt
@@ -19,7 +19,7 @@ java-utilities
 
 # optional autocomplete feature
 jedi==0.19.1
-docstring_parser==0.16
+docstring_parser>=0.16
 
 # optional adbc feature
 adbc-driver-manager

--- a/contexts/server-base/requirements.txt
+++ b/contexts/server-base/requirements.txt
@@ -19,6 +19,7 @@ java-utilities
 
 # optional autocomplete feature
 jedi==0.19.1
+docstring_parser==0.16
 
 # optional adbc feature
 adbc-driver-manager


### PR DESCRIPTION
- Add `docstring_parser==0.16` to `requirements.txt`
- Related core PR: https://github.com/deephaven/deephaven-core/pull/6170
- Related issue: https://github.com/deephaven/web-client-ui/issues/2247