### PR TITLE
Include numba for python 3.12

### DIFF
--- a/contexts/server-base/requirements.txt
+++ b/contexts/server-base/requirements.txt
@@ -9,7 +9,7 @@ deephaven-plugin>=0.6.0
 numpy
 pandas>=1.5.0
 pyarrow
-numba; python_version < "3.12"
+numba; python_version < "3.13"
 
 # deephaven-core also expects wheel to be installed...
 wheel


### PR DESCRIPTION
Follow-up to https://github.com/deephaven/deephaven-core/pull/5130