### PR TITLE
chore: bump to jpy>=0.19.0

### DIFF
--- a/contexts/server-base/requirements.txt
+++ b/contexts/server-base/requirements.txt
@@ -4,7 +4,7 @@
 # These are dependencies of deephaven-core[autocomplete], not including deephaven-core.
 #
 # See https://github.com/deephaven/deephaven-core/blob/main/py/server/setup.py
-jpy>=0.18.0
+jpy>=0.19.0
 deephaven-plugin>=0.6.0
 numpy
 pandas>=1.5.0

--- a/contexts/server-base/type/server-all-ai/requirements.txt
+++ b/contexts/server-base/type/server-all-ai/requirements.txt
@@ -1,5 +1,5 @@
 # Note: this is targetted as the dependencies of deephaven-core, but not including deephaven-core
-jpy>=0.18.0
+jpy>=0.19.0
 deephaven-plugin>=0.5.0
 numpy
 pandas>=1.5.0


### PR DESCRIPTION
See https://github.com/jpy-consortium/jpy/releases/tag/v0.19.0