### PR TITLE
Bake action v6

### DIFF
--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -101,7 +101,7 @@ jobs:
           cp artifacts/server/jetty-app/build/distributions/server-jetty-${{ steps.artifact_metadata.outputs.deephaven_version }}.tar contexts/server-slim/
 
       - name: Bake
-        uses: docker/bake-action@v5.11.0
+        uses: docker/bake-action@v6.4.0
         with:
           targets: ${{ github.event.inputs.bake_targets }}
           files: server.hcl,server-slim.hcl,server-base.hcl,server-slim-base.hcl

--- a/.github/workflows/branch-ci.yml
+++ b/.github/workflows/branch-ci.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Bake
         uses: docker/bake-action@v6.4.0
         with:
+          source: .
           targets: ${{ github.event.inputs.bake_targets }}
           files: server.hcl,server-slim.hcl,server-base.hcl,server-slim-base.hcl
           pull: true

--- a/.github/workflows/edge-ci.yml
+++ b/.github/workflows/edge-ci.yml
@@ -106,7 +106,7 @@ jobs:
           cp artifacts/server/jetty-app/build/distributions/server-jetty-${{ steps.artifact_metadata.outputs.deephaven_version }}.tar contexts/server-slim/
 
       - name: Bake
-        uses: docker/bake-action@v5.11.0
+        uses: docker/bake-action@v6.4.0
         with:
           targets: server,server-slim,server-base,server-slim-base
           files: server.hcl,server-slim.hcl,server-base.hcl,server-slim-base.hcl

--- a/.github/workflows/edge-ci.yml
+++ b/.github/workflows/edge-ci.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Bake
         uses: docker/bake-action@v6.4.0
         with:
+          source: .
           targets: server,server-slim,server-base,server-slim-base
           files: server.hcl,server-slim.hcl,server-base.hcl,server-slim-base.hcl
           pull: true

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -14,9 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-24.04-4-16
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bake
-        uses: docker/bake-action@v5.11.0
+        uses: docker/bake-action@v6.4.0
         with:
           targets: server,server-slim,server-all-ai,server-nltk,server-pytorch,server-sklearn,server-tensorflow
           files: server.hcl,server-slim.hcl


### PR DESCRIPTION
Jobs that rely on local changes need to set the path context.

https://github.com/docker/bake-action/releases/tag/v6.0.0

https://github.com/docker/bake-action/tree/v6.0.0?tab=readme-ov-file#git-context